### PR TITLE
Add CheckStopped before CheckPreRetirement

### DIFF
--- a/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/__class__.yaml
+++ b/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/__class__.yaml
@@ -1,0 +1,213 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Methods
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: relationship
+      name: rel1
+      display_name: Relationship
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth1
+      display_name: Method
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: redhat_meth1
+      display_name: RedHat
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: redhat
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: redhat_rel1
+      display_name: RedHat
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: redhat
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: vmware_meth1
+      display_name: VMWare
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: vmware
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: vmware_rel1
+      display_name: VMWare
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: vmware
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: common_rel1
+      display_name: Common
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: common_meth1
+      display_name: Common
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: microsoft_rel1
+      display_name: Microsoft
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: microsoft
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: microsoft_meth1
+      display_name: Microsoft
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: microsoft
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_stopped.rb
+++ b/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_stopped.rb
@@ -1,0 +1,45 @@
+# Checks that a Vmware VM has been stopped before CheckPreRetirement
+# This is to work around the "unknown" status being returned
+# EXPECTED
+#   EVM ROOT
+#     vm - VM to check power state for
+@DEBUG = false
+
+# Log an error and exit.
+#
+# @param msg Message to error with
+def error(msg)
+  $evm.log(:error, msg)
+  $evm.root['ae_result'] = 'error'
+  $evm.root['ae_reason'] = msg.to_s
+  exit MIQ_STOP
+end
+
+def check_power_state(vm)
+  ems = vm.ext_management_system if vm
+  if vm.nil? || ems.nil?
+    $evm.log('info', "Skipping check pre retirement for VM:<#{vm.try(:name)}> on EMS:<#{ems.try(:name)}>")
+    return
+  end
+
+  power_state = vm.power_state
+  $evm.log('info', "VM:<#{vm.name}> on Provider:<#{ems.name}> has Power State:<#{power_state}>")
+
+  # If VM is powered off or suspended exit
+
+  if %w(off suspended).include?(power_state)
+    $evm.root['ae_result'] = 'ok'
+  elsif power_state == "never"
+    # If never then this VM is a template so exit the retirement state machine
+    $evm.root['ae_result'] = 'error'
+  else
+    $evm.root['ae_result'] = 'retry'
+    $evm.root['ae_retry_interval'] = '60.seconds'
+  end
+end
+
+begin
+  vm = $evm.root['vm']
+  
+  check_power_state(vm)
+end

--- a/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_stopped.yaml
+++ b/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/__methods__/check_stopped.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: check_stopped
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/checkstopped.yaml
+++ b/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/Methods.class/checkstopped.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CheckStopped
+    inherits: 
+    description: 
+  fields:
+  - vmware_meth1:
+      value: check_stopped

--- a/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
+++ b/Automate/RedHatConsulting_Satellite6/Infrastructure/VM/Retirement/StateMachines/VMRetirement.class/__class__.yaml
@@ -53,10 +53,30 @@ object:
       max_time: 
   - field:
       aetype: state
-      name: CheckPreRetirement
+      name: CheckStopped
       display_name: 
       datatype: string
       priority: 3
+      owner: 
+      default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/CheckStopped#${/#vm.vendor}"
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: update_retirement_status(status => 'Starting CheckStopped')
+      on_exit: update_retirement_status(status => 'CheckStopped successful')
+      on_error: update_retirement_status(status => 'Error in CheckPreRetirement')
+      max_retries: '100'
+      max_time: 
+  - field:
+      aetype: state
+      name: CheckPreRetirement
+      display_name: 
+      datatype: string
+      priority: 4
       owner: 
       default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/CheckPreRetirement#${/#vm.vendor}"
       substitute: true
@@ -76,7 +96,7 @@ object:
       name: DeactivateCMDB
       display_name: 
       datatype: string
-      priority: 4
+      priority: 5
       owner: 
       default_value: 
       substitute: true
@@ -96,7 +116,7 @@ object:
       name: UnregisterSatellite
       display_name: 
       datatype: string
-      priority: 5
+      priority: 6
       owner: 
       default_value: 
       substitute: true
@@ -116,7 +136,7 @@ object:
       name: UnregisterDHCP
       display_name: 
       datatype: string
-      priority: 6
+      priority: 7
       owner: 
       default_value: 
       substitute: true
@@ -136,7 +156,7 @@ object:
       name: UnregisterAD
       display_name: 
       datatype: string
-      priority: 7
+      priority: 8
       owner: 
       default_value: 
       substitute: true
@@ -156,7 +176,7 @@ object:
       name: UnregisterDNS
       display_name: 
       datatype: string
-      priority: 8
+      priority: 9
       owner: 
       default_value: 
       substitute: true
@@ -176,7 +196,7 @@ object:
       name: ReleaseMACAddress
       display_name: 
       datatype: string
-      priority: 9
+      priority: 10
       owner: 
       default_value: 
       substitute: true
@@ -196,7 +216,7 @@ object:
       name: ReleaseIPAddress
       display_name: 
       datatype: string
-      priority: 10
+      priority: 11
       owner: 
       default_value: 
       substitute: true
@@ -216,7 +236,7 @@ object:
       name: PreDeleteFromProvider
       display_name: 
       datatype: string
-      priority: 11
+      priority: 12
       owner: 
       default_value: "#/Infrastructure/VM/Retirement/StateMachines/Methods/PreDeleteFromProvider"
       substitute: true
@@ -236,7 +256,7 @@ object:
       name: RemoveFromProvider
       display_name: 
       datatype: string
-      priority: 12
+      priority: 13
       owner: 
       default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/RemoveFromProvider"
       substitute: true
@@ -256,7 +276,7 @@ object:
       name: PreDeleteEmailOwner
       display_name: 
       datatype: string
-      priority: 13
+      priority: 14
       owner: 
       default_value: "#/Infrastructure/VM/Retirement/Email/vm_retirement_emails?event=vm_entered_retirement"
       substitute: true
@@ -276,7 +296,7 @@ object:
       name: EmailOwner
       display_name: 
       datatype: string
-      priority: 14
+      priority: 15
       owner: 
       default_value: "/Infrastructure/VM/Retirement/Email/vm_retirement_emails?event=vm_retired"
       substitute: true
@@ -296,7 +316,7 @@ object:
       name: CheckRemovedFromProvider
       display_name: 
       datatype: string
-      priority: 15
+      priority: 16
       owner: 
       default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/CheckDeletedFromProvider"
       substitute: true
@@ -316,7 +336,7 @@ object:
       name: FinishRetirement
       display_name: 
       datatype: string
-      priority: 16
+      priority: 17
       owner: 
       default_value: "/Infrastructure/VM/Retirement/StateMachines/Methods/FinishRetirement"
       substitute: true
@@ -336,7 +356,7 @@ object:
       name: DeleteFromVMDB
       display_name: 
       datatype: string
-      priority: 17
+      priority: 18
       owner: 
       default_value: "#/Infrastructure/VM/Retirement/StateMachines/Methods/DeleteFromVMDB"
       substitute: true


### PR DESCRIPTION
Prevents VMs from ending up in a broken state if VMware returns "unknown" as the status during retirement