### PR TITLE
More specific error for Unprocessable Entity

### DIFF
--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
@@ -107,7 +107,9 @@ begin
   begin
     satellite_host_record = satellite_api.resource(:hosts).call(:create, { :host => new_host_request })
     $evm.log(:info, "satellite_host_record => #{satellite_host_record}")
-  rescue => e
+  rescue RestClient::UnprocessableEntity => e
+    error("Received an UnprocessableEntity error from Satellite. This is often caused by hostgroup issues.")
+  rescue Exception => e
     error("Error creating Satellite host record: #{e.message}")
   end
   

--- a/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
+++ b/Automate/RedHatConsulting_Satellite6/Integration/Satellite/Operations/Methods.class/__methods__/register_satellite.rb
@@ -108,7 +108,7 @@ begin
     satellite_host_record = satellite_api.resource(:hosts).call(:create, { :host => new_host_request })
     $evm.log(:info, "satellite_host_record => #{satellite_host_record}")
   rescue RestClient::UnprocessableEntity => e
-    error("Received an UnprocessableEntity error from Satellite. This is often caused by hostgroup issues.")
+    error("Received an UnprocessableEntity error from Satellite. Check /var/log/foreman/production.log on Satellite for more info.")
   rescue Exception => e
     error("Error creating Satellite host record: #{e.message}")
   end


### PR DESCRIPTION
Receiving an Unprocessable Entity error from Satellite currently creates a difficult to decipher message on the request. This pull request adds a more specific error message when that response is received from Satellite, pointing the user to check that nothing is wrong with their hostgroups.